### PR TITLE
build from source, enable rttopo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM alpine as build
+FROM alpine:3.7 as build
 
-RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-RUN echo "@edge-testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+RUN echo "@edge-testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 
 RUN apk update && \
   apk --no-cache --update upgrade musl && \
-  apk add --upgrade apk-tools@edge && \
-  apk add --update wget gcc make automake libtool autoconf fossil git libc-dev sqlite-dev zlib-dev libxml2-dev "proj4-dev@edge-testing" "geos-dev@edge-testing" "gdal-dev@edge-testing" "gdal@edge-testing" expat-dev readline-dev ncurses-dev readline ncurses-static libc6-compat && \
+  apk add --upgrade --force-overwrite apk-tools@edge && \
+  apk add --update --force-overwrite wget gcc make automake libtool autoconf curl fossil git libc-dev sqlite-dev zlib-dev libxml2-dev "proj-dev@edge-testing" "geos-dev@edge-testing" "gdal-dev@edge-testing" "gdal@edge-testing" expat-dev readline-dev ncurses-dev readline ncurses-static libc6-compat && \
   rm -rf /var/cache/apk/*
 
 ENV USER me

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,24 @@ FROM alpine as build
 
 RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 RUN echo "@edge-testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN apk update
 
-RUN apk add wget gcc make libc-dev sqlite-dev zlib-dev libxml2-dev "proj4-dev@edge-testing" "geos-dev@edge-testing" "gdal-dev@edge-testing" "gdal@edge-testing" expat-dev readline-dev ncurses-dev readline-static ncurses-static libc6-compat
+RUN apk update && \
+  apk --no-cache --update upgrade musl && \
+  apk add --upgrade apk-tools@edge && \
+  apk add --update wget gcc make automake libtool autoconf fossil git libc-dev sqlite-dev zlib-dev libxml2-dev "proj4-dev@edge-testing" "geos-dev@edge-testing" "gdal-dev@edge-testing" "gdal@edge-testing" expat-dev readline-dev ncurses-dev readline ncurses-static libc6-compat && \
+  rm -rf /var/cache/apk/*
 
-RUN wget "http://www.gaia-gis.it/gaia-sins/freexl-1.0.4.tar.gz" && tar zxvf freexl-1.0.4.tar.gz && cd freexl-1.0.4 && ./configure && make && make install
+ENV USER me
 
-RUN wget "http://www.gaia-gis.it/gaia-sins/libspatialite-4.3.0a.tar.gz" && tar zxvf libspatialite-4.3.0a.tar.gz && cd libspatialite-4.3.0a && ./configure && make && make install
+RUN fossil clone https://www.gaia-gis.it/fossil/freexl freexl.fossil && mkdir freexl && cd freexl && fossil open ../freexl.fossil && ./configure && make -j8 && make install
 
-RUN wget "http://www.gaia-gis.it/gaia-sins/readosm-1.1.0.tar.gz" && tar zxvf readosm-1.1.0.tar.gz && cd readosm-1.1.0 && ./configure && make && make install
+RUN git clone "https://git.osgeo.org/gitea/rttopo/librttopo.git" && cd librttopo && ./autogen.sh && ./configure && make -j8 && make install
 
-RUN wget "http://www.gaia-gis.it/gaia-sins/spatialite-tools-4.3.0.tar.gz" && tar zxvf spatialite-tools-4.3.0.tar.gz && cd spatialite-tools-4.3.0 && ./configure && make && make install
+RUN fossil clone https://www.gaia-gis.it/fossil/libspatialite libspatialite.fossil && mkdir libspatialite && cd libspatialite && fossil open ../libspatialite.fossil && ./configure --enable-rttopo --enable-geocallbacks --enable-gcp=yes --enable-libxml2 && make -j8 && make install
+
+RUN fossil clone https://www.gaia-gis.it/fossil/readosm readosm.fossil && mkdir readosm && cd readosm && fossil open ../readosm.fossil && ./configure && make -j8 && make install
+
+RUN fossil clone https://www.gaia-gis.it/fossil/spatialite-tools spatialite-tools.fossil && mkdir spatialite-tools && cd spatialite-tools && fossil open ../spatialite-tools.fossil && ./configure && make -j8 && make install
 
 RUN cp /usr/local/bin/* /usr/bin/
 RUN cp -R /usr/local/lib/* /usr/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,16 @@ RUN cp -R /usr/local/lib/* /usr/lib/
 # Create a minimal instance
 FROM alpine
 
+# copy libs (maintaining symlinks)
 COPY --from=build /usr/lib/ /usr/lib
-COPY --from=build /usr/bin/ /usr/bin
+
+# remove broken symlinks
+RUN find -L /usr/lib -maxdepth 1 -type l -delete
+
+# remove directories
+RUN find /usr/lib -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
+
+# copy binaries
+COPY --from=build /usr/bin/spatialite* /usr/bin/
 
 ENTRYPOINT ["spatialite"]


### PR DESCRIPTION
Heya,

This PR uses `fossil` to fetch the sources from VCS and builds from `master` (the published source `.gz` files are super old `09-May-2016` and I needed a more recent bugfix).

I also added `librttopo` via `git` so that the functions listed under `LWGEOM` in the readme are added (so functions like `ST_MakeValid` and `ST_Split` should now be available).

Tested that it builds correctly, tested additional functions available.

